### PR TITLE
Partial fix for bezier rendering

### DIFF
--- a/src/CAD/Curve.cc
+++ b/src/CAD/Curve.cc
@@ -1,43 +1,42 @@
 #define _USE_MATH_DEFINES
 #include "CAD/Curve.hh"
-#include "glad/glad.h"
-#include "opengl/Shader.hh"
-#include "opengl/GLWin.hh"
-#include "opengl/Canvas.hh"
+
 #include <cmath>
+
+#include "glad/glad.h"
+#include "opengl/Canvas.hh"
+#include "opengl/GLWin.hh"
+#include "opengl/Shader.hh"
 
 using namespace std;
 
-void Curve::add(const Vec3D& p){
-  points.push_back(p);
-}
+void Curve::add(const Vec3D& p) { points.push_back(p); }
 
-void Curve::compute(){
+void Curve::compute() {
   p = normalize(point);
-  u = cross(center, p); //get perpendicular vector
-  u = normalize(u); //normalize to get unit vector
-  v = cross(u,p); //get perpendicular vector
-  v = normalize(v); //normalize to get unit vector
+  u = cross(center, p);  // get perpendicular vector
+  u = normalize(u);      // normalize to get unit vector
+  v = cross(u, p);       // get perpendicular vector
+  v = normalize(v);      // normalize to get unit vector
 }
 
-Vec3D Curve::getPoint(double step){
+Vec3D Curve::getPoint(double step) {
   double t = M_PI * 2 * step;
   compute();
-  return center + (u*(radius*cos(t))) + (v*(radius*sin(t)));
+  return center + (u * (radius * cos(t))) + (v * (radius * sin(t)));
 }
 
-
-void Curve::getPoints(){
-  for(double i=0; i<=0.5; i+=0.1){
-     // cout<< this->getPoint(i) << endl;
-      points.push_back(this->getPoint(i));
+void Curve::getPoints() {
+  for (double i = 0; i <= 0.5; i += 0.1) {
+    // cout<< this->getPoint(i) << endl;
+    points.push_back(this->getPoint(i));
   }
 }
-//unwrap points to be a 1d array for drawing
-std::vector<float> unwrap(std::vector<Vec3D> x){
+// unwrap points to be a 1d array for drawing
+std::vector<float> unwrap(std::vector<Vec3D> x) {
   std::vector<float> temp;
-  temp.reserve(x.size()*3);
-  for (int i=0; i<x.size(); i++){
+  temp.reserve(x.size() * 3);
+  for (int i = 0; i < x.size(); i++) {
     temp.push_back(x[i].x);
     temp.push_back(x[i].y);
     temp.push_back(x[i].z);
@@ -45,39 +44,39 @@ std::vector<float> unwrap(std::vector<Vec3D> x){
   return temp;
 }
 
-void Curve::init(){
-  //create VAO to hold shapes
+void Curve::init() {
+  // create VAO to hold shapes
   glGenVertexArrays(1, &vao);
   glBindVertexArray(vao);
-  
-  //create VBO to hold vertex points
+
+  // create VBO to hold vertex points
   drawingPoints = unwrap(points);
+  numPoints = drawingPoints.size()/elemPerVert;
   glGenBuffers(1, &vbo);
   glBindBuffer(GL_ARRAY_BUFFER, vbo);
-  glBufferData(GL_ARRAY_BUFFER, 18 * sizeof(float), &drawingPoints[0], GL_STATIC_DRAW);
-
-  //describe in shaders
-  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 18 * sizeof(float), (void*)0);
+  glBufferData(GL_ARRAY_BUFFER, 18 * sizeof(float), &drawingPoints[0],
+               GL_STATIC_DRAW);
+  
+  glVertexAttribPointer(0, elemPerVert, GL_FLOAT, GL_FALSE, 0, (void*)0);
 }
 
-void Curve::render(){
-  for(int i=0; i<drawingPoints.size(); i++){
-    cout << drawingPoints[i] << " " ;
+void Curve::render() {
+  for (int i = 0; i < drawingPoints.size(); i++) {
+    cout << drawingPoints[i] << " ";
   }
-  cout << endl ;
+  cout << endl;
 
-  Shader * shader = Shader::useShader(GLWin::COMMON_SHADER);
-  shader->setMat4("projection",*(parentCanvas->getProjection()));
-	shader->setVec4("solidColor",style->getFgColor());
+  Shader* shader = Shader::useShader(GLWin::COMMON_SHADER);
+  shader->setMat4("projection", *(parentCanvas->getProjection()));
+  shader->setVec4("solidColor", style->getFgColor());
   glBindVertexArray(vao);
   glEnableVertexAttribArray(0);
 
   glLineWidth(style->getLineWidth());
-  glDrawArrays(GL_LINES, 0, 6);
+  glDrawArrays(GL_LINE_STRIP, 0, numPoints);
 
   glDisableVertexAttribArray(0);
   glBindVertexArray(0);
-
 }
 
 // #if 0

--- a/src/CAD/Curve.hh
+++ b/src/CAD/Curve.hh
@@ -18,13 +18,16 @@ class Curve : public Vec3D, public Shape2D {
     Vec3D center; 
     Vec3D p, u, v;
     std::vector<float> drawingPoints;
-  
-  public:
+    uint8_t elemPerVert;
+    uint64_t numPoints;
+
+   public:
     Curve(Vec3D p1, Vec3D p2, Canvas* c, Style* s) 
       :Shape2D(c, p1.x, p1.y, s){
       this->point=p1;
       this->center=midpoint(p1,p2);
       this->radius=distance(p1,p2)/2;
+      this->elemPerVert = 3;
       this->getPoints();
     }
 


### PR DESCRIPTION
Curve.hh: Adds two new parameters, elemPerVert and numPoints. This is so
we can easily force opengl to treat the points as if they were 2D points
instead of 3D points. This is primarily for debugging and should be
removed later.

Curve.cc: Most of the diff is the formatter running. The actual changes
happened in Curve::init and Curve::render.

Previously the stride was set to 18*sizeof(float), however the stride describes
the distance between a set of points in the array. Since our points are densely
packed, the stride can be set to 0.

An idea we could try at one point is to set the stride to be (elemPerVert -
the debugging point size). So if we wanted to force (x,y) mode instead
of (x,y,z), we could set the stride to be 1 so it skips the z-coordinate
of each point.

As for Curve::render, the number of points has been generalized to
numPoints (set in Curve::init). This is just to remove the "magic
number" that may not make as much sense later. If this is going to be
constant, we can always make numPoints a const. glDrawArrays has also
been changed from GL_LINES to GL_LINE_STRIP. The layout of the array
puts all the vertices we want to connect right next to each other, and
GL_LINE_STRIP will draw n-1 lines using the contiguous vertex data.
GL_LINES instead tries to draw lines between vertex 0 and 1, 2 and 3,
etc.