### PR TITLE
Linker errors in bezier_kaiqichee

### DIFF
--- a/src/CAD/BezierPath.cc
+++ b/src/CAD/BezierPath.cc
@@ -1,5 +1,4 @@
 #include "CAD/BezierPath.hh"
-#include "CAD/Vec3d.hh"
 //#include "CAD/Matrix3d.hh"
 
 using namespace std;

--- a/src/CAD/BezierPath.hh
+++ b/src/CAD/BezierPath.hh
@@ -1,7 +1,6 @@
 #pragma once
 #include "opengl/GrailGUI.hh"
-#include "./Vec3d.hh"
-//#include "./Curve.hh"
+#include "CAD/Curve.hh"
 #include <vector>
 #include "opengl/Shape2D.hh"
 

--- a/src/CAD/BezierPath.hh
+++ b/src/CAD/BezierPath.hh
@@ -1,6 +1,6 @@
 #pragma once
 #include "opengl/GrailGUI.hh"
-#include "CAD/Curve.hh"
+#include "CAD/Vec3d.hh"
 #include <vector>
 #include "opengl/Shape2D.hh"
 

--- a/src/CAD/CMakeLists.txt
+++ b/src/CAD/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(grail-CAD
     Curve.cc
     Circle.cc
-    Bezier.cc
+    BezierPath.cc
 )
 
 list(TRANSFORM grail-CAD PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)

--- a/src/CAD/Curve.hh
+++ b/src/CAD/Curve.hh
@@ -2,7 +2,7 @@
 // #include "opengl/GrailGUI.hh"
 // #include "opengl/util/Transformation.hh"
 //#include "opengl/MultiShape3D.hh"
-#include "./Vec3d.hh"
+#include "CAD/Vec3d.hh"
 #include <vector>
 #include "opengl/Shape2D.hh"
 
@@ -23,7 +23,7 @@ class Curve : public Vec3D, public Shape2D {
     Curve(Vec3D p1, Vec3D p2, Canvas* c, Style* s) 
       :Shape2D(c, p1.x, p1.y, s){
       this->point=p1;
-      this->center=midpoint(p1,p2);
+      this->center = midpoint(p1, p2);
       this->radius=distance(p1,p2)/2;
       this->getPoints();
     }
@@ -40,7 +40,7 @@ class Curve : public Vec3D, public Shape2D {
  // virtual Vec3D getTangent(double step) = 0; //virtual replaces "abstract" from java
   
   // Overload the << operator
-  friend std::ostream& operator<< (ostream& s, const Curve& c){
+  friend std::ostream& operator<< (std::ostream& s, const Curve& c){
     for (int i = 0; i < c.points.size(); i++){
       s << c.points[i] << ",";
     }

--- a/src/CAD/Vec3d.hh
+++ b/src/CAD/Vec3d.hh
@@ -1,86 +1,73 @@
 #pragma once
-#include <iostream>
 #include <cmath>
-
-using namespace std;
-
+#include <iostream>
 
 // create constructor to create the vec_3d objects
-class Vec3D{
-public:
-double x;
-double y;
-double z;
-Vec3D(double x = 0, double y = 0, double z = 0) : x(x), y(y), z(z){}
+class Vec3D {
+ public:
+  double x;
+  double y;
+  double z;
+  Vec3D(double x = 0, double y = 0, double z = 0) : x(x), y(y), z(z) {}
 
-// overload operators for vector math
-friend Vec3D operator+ (const Vec3D& a, const Vec3D& b){
-  return Vec3D(a.x + b.x, a.y + b.y, a.z + b.z);
-}
-friend Vec3D operator- (const Vec3D& a, const Vec3D& b){
-  return Vec3D(a.x - b.x, a.y - b.y, a.z - b.z);
-}
-friend Vec3D operator* (const Vec3D& a, double s){
-  return Vec3D(a.x * s, a.y * s, a.z * s);
-}
-friend Vec3D operator/ (const Vec3D& a, double s){
-  return Vec3D(a.x / s, a.y / s, a.z / s);
-}
-
-
-Vec3D operator- () const {
-  return Vec3D(-x, -y, -z);
-}
-// create three methods to compute various vector properties
-double mag() const {
-  return sqrt(magsq());
-}
-double magsq() const {
-  return x*x+y*y+z*z;
-}
-Vec3D normalize(const Vec3D& a){
-  if (a.mag() == 0){
-    return Vec3D(0,0,0);
+  // overload operators for vector math
+  friend Vec3D operator+(const Vec3D& a, const Vec3D& b) {
+    return Vec3D(a.x + b.x, a.y + b.y, a.z + b.z);
   }
-  else{
-    return a/a.mag();
+  friend Vec3D operator-(const Vec3D& a, const Vec3D& b) {
+    return Vec3D(a.x - b.x, a.y - b.y, a.z - b.z);
   }
-}
+  friend Vec3D operator*(const Vec3D& a, double s) {
+    return Vec3D(a.x * s, a.y * s, a.z * s);
+  }
+  friend Vec3D operator/(const Vec3D& a, double s) {
+    return Vec3D(a.x / s, a.y / s, a.z / s);
+  }
 
-double dot(const Vec3D& b) const {
-return x * b.x + y * b.y + z * b.z;
-}
+  Vec3D operator-() const { return Vec3D(-x, -y, -z); }
+  // create three methods to compute various vector properties
+  double mag() const { return sqrt(magsq()); }
+  double magsq() const { return x * x + y * y + z * z; }
+  Vec3D normalize(const Vec3D& a) {
+    if (a.mag() == 0) {
+      return Vec3D(0, 0, 0);
+    } else {
+      return a / a.mag();
+    }
+  }
+
+  // compute the dot product as a function
+  friend double dot(const Vec3D& a, const Vec3D& b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+  }
+  friend Vec3D cross(const Vec3D& a, const Vec3D& b) {
+    double cx = (a.y * b.z) - (a.z * b.y);
+    double cy = (a.z * b.x) - (a.x * b.z);
+    double cz = (a.x * b.y) - (a.y * b.x);
+    return Vec3D(cx, cy, cz);
+  }
+
+  friend double distance(const Vec3D& a, const Vec3D& b) {
+    return sqrt(pow(b.x - a.x, 2) + pow(b.y - a.y, 2) + pow(b.z - a.z, 2));
+  }
+
+  friend Vec3D midpoint(const Vec3D& a, const Vec3D& b) {
+    return Vec3D(((a.x + b.x) / 2), ((a.y + b.y) / 2), ((a.z + b.z) / 2));
+  }
+
+  // Overload the << operator
+  friend std::ostream& operator<<(std::ostream& s, const Vec3D& v) {
+    return s << "(" << v.x << "," << v.y << "," << v.z << ")";
+  }
+  // Overload the >> operator
+  friend std::istream& operator>>(std::istream& s, Vec3D& v) {
+    return s >> v.x >> v.y >> v.z;
+  }
 };
-// compute the dot product as a function
-double dot(const Vec3D& a, const Vec3D& b){
-return a.x * b.x + a.y * b.y + a.z * b.z;
-}
-Vec3D cross(const Vec3D& a, const Vec3D& b) {
-  double cx = (a.y * b.z) - (a.z * b.y);
-  double cy = (a.z * b.x) - (a.x * b.z);
-  double cz = (a.x * b.y) - (a.y * b.x);
-  return Vec3D(cx, cy, cz);
-}
 
-double distance(const Vec3D& a, const Vec3D& b) {
-  return sqrt(pow(b.x-a.x, 2) + pow(b.y-a.y, 2) + pow(b.z-a.z, 2));
-}
-
-Vec3D midpoint(const Vec3D& a, const Vec3D& b) {
-  return Vec3D(((a.x+b.x)/2), ((a.y+b.y)/2), ((a.z+b.z)/2));
-}
-
-// Overload the << operator
-std::ostream& operator<< (std::ostream& s, const Vec3D& v){
-return s << "(" << v.x <<"," << v.y << "," << v.z <<")";
-}
-// Overload the >> operator
-std::istream& operator>> (std::istream& s, Vec3D& v){
-return s >> v.x >> v.y >> v.z;
-}
 // int main() {
 // const Vec3D a(1,2,3);
 // const Vec3D b(1,2,3);
-// cout << a.magsq(); 
+// cout << a.magsq();
 // cout << a << b;
 // }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(data)
 add_subdirectory(opengl)
 add_subdirectory(util)
 add_subdirectory(xdl)
+add_subdirectory(CAD)
 
 set(grail-path
             ${PROJECT_SOURCE_DIR}/include/glad/glad.c
@@ -11,8 +12,8 @@ set(grail-path
             ${grail-opengl}
             ${grail-util}
             ${grail-xdl}
-	    ${grail-CAD}
-            )
+	          ${grail-CAD}
+)
 
 
 if(${GRAIL_EXPERIMENTAL})

--- a/test/CurveTest.cc
+++ b/test/CurveTest.cc
@@ -3,9 +3,7 @@
 #include "CAD/BezierPath.hh"
 #include "opengl/StyledMultiShape2D.hh"
 
-
-#include "iostream"
-#include "CAD/Vec3d.hh"
+#include <iostream>
 #include "opengl/GrailGUI.hh"
 #include "opengl/util/Camera.hh"
 


### PR DESCRIPTION
## Issues
  Previously, attempting to compile this would lead to a linker error due to src/CAD/ not being included in the compile step. This was fixed relatively quickly, but exposed several multiple-definition issues with CAD/Vec3d.hh. These issues seemed unusual, but were fixed as soon as the functions in question were moved into the class definition. Issues like this are usually due to a .cc/.cpp file being included as if it were a header file, but that does not seem to be an issue here.

## Changelog

- src/CMakeLists.txt: CAD subdirectory was never added before attempting to add the grail-CAD variable to the build path. I'm not sure if this ever would have worked.
- BezierPath.cc: CAD/Vec3d.hh was included in BezierPath.hh, so the redundant include was removed
- BezierPath.hh: changed Vec3d include from "./Vec3d.hh" to  "CAD/Vec3d.hh" for clarity purposes
- CAD/CMakeLists.txt: BezierPath was never being compiled, instead CMake would have tried to compile a non-existent file called Bezier.cc. Given that this directory was never being compiled though, it didn't emit any errors.
- Curve.hh: See BezierPath.hh, the same fix was applied.
- Vec3d.hh: A lot of the visible changes are just from running the formatter on it. However, the most apparent changes are from moving the functions outside the class definition (dot, cross, distance, operator<<, operator>>) into the class as friend functions. For whatever reason, leaving them outside the class definition is causing multiple definition errors. Moving them into the class definition seems to have resolved this.
- CurveTest.cc: Mostly style changes with the includes.